### PR TITLE
Current legacy parser

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "uap-core"]
 	path = uap-core
 	url = https://github.com/ua-parser/uap-core.git
+[submodule "uap-core-legacy"]
+	path = uap-core-legacy
+	url = https://github.com/ua-parser/uap-core

--- a/README.md
+++ b/README.md
@@ -17,32 +17,42 @@ mvn package
 
 Usage:
 --------
+
+There are two Parser classes: `CurrentParser` and `LegacyParser` with identical interfaces.
+`CurrentParser` uses a slightly newer version of `uap-core` with an updated user agent parser.
+That version of `uap-core` is synced with the one `popper` uses as a part of `uap-python`.
+`LegacyParser` uses a version of `uap-core` from early 2018. It's the version which was used
+when the frozen DMP realtime models have been created.
+
+Use them as following:
+
 ```java
 import ua_parser.Parser;
 import ua_parser.Client;
 
-...
+class SomeClass {
 
-String uaString = "Mozilla/5.0 (iPhone; CPU iPhone OS 5_1_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9B206 Safari/7534.48.3";
+    void SomeMethod() {
+        String uaString = 
+                "Mozilla/5.0 (iPhone; CPU iPhone OS 5_1_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9B206 Safari/7534.48.3";
 
-Parser uaParser = new Parser();
-Client c = uaParser.parse(uaString);
+        Parser uaParser = new CurrentParser();
+        Client c = uaParser.parse(uaString);
 
-System.out.println(c.userAgent.family); // => "Mobile Safari"
-System.out.println(c.userAgent.major);  // => "5"
-System.out.println(c.userAgent.minor);  // => "1"
+        System.out.println(c.userAgent.family); // => "Mobile Safari"
+        System.out.println(c.userAgent.major);  // => "5"
+        System.out.println(c.userAgent.minor);  // => "1"
 
-System.out.println(c.os.family);        // => "iOS"
-System.out.println(c.os.major);         // => "5"
-System.out.println(c.os.minor);         // => "1"
+        System.out.println(c.os.family);        // => "iOS"
+        System.out.println(c.os.major);         // => "5"
+        System.out.println(c.os.minor);         // => "1"
 
-System.out.println(c.device.family);    // => "iPhone"
+        System.out.println(c.device.family);    // => "iPhone"
+    }
+}
 ```
 
-### Instructions for Build/Deploy/Releas
-
-
-Author:
+Original Author:
 -------
 
 * Steve Jiang [@sjiang](https://twitter.com/sjiang)

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,15 @@
   <build>
     <resources>
       <resource>
-        <targetPath>ua_parser</targetPath>
+        <targetPath>ua_parser/current</targetPath>
         <directory>${basedir}/uap-core</directory>
+        <includes>
+          <include>regexes.yaml</include>
+        </includes>
+      </resource>
+      <resource>
+        <targetPath>ua_parser/legacy</targetPath>
+        <directory>${basedir}/uap-core-legacy</directory>
         <includes>
           <include>regexes.yaml</include>
         </includes>
@@ -57,15 +64,29 @@
 
     <testResources>
       <testResource>
-        <targetPath>ua_parser</targetPath>
+        <targetPath>ua_parser/current</targetPath>
         <directory>${basedir}/uap-core/test_resources</directory>
         <includes>
           <include>*.yaml</include>
         </includes>
       </testResource>
       <testResource>
-        <targetPath>ua_parser</targetPath>
+        <targetPath>ua_parser/current</targetPath>
         <directory>${basedir}/uap-core/tests</directory>
+        <includes>
+          <include>*.yaml</include>
+        </includes>
+      </testResource>
+      <testResource>
+        <targetPath>ua_parser/legacy</targetPath>
+        <directory>${basedir}/uap-core-legacy/test_resources</directory>
+        <includes>
+          <include>*.yaml</include>
+        </includes>
+      </testResource>
+      <testResource>
+        <targetPath>ua_parser/legacy</targetPath>
+        <directory>${basedir}/uap-core-legacy/tests</directory>
         <includes>
           <include>*.yaml</include>
         </includes>

--- a/src/main/java/ua_parser/CachingParser.java
+++ b/src/main/java/ua_parser/CachingParser.java
@@ -17,7 +17,7 @@ import org.apache.commons.collections4.map.LRUMap;
  *
  * @author Niels Basjes
  */
-public class CachingParser extends Parser {
+public class CachingParser extends CurrentParser {
 
     private Map<String, Client> cacheClient = null;
     private Map<String, UserAgent> cacheUserAgent = null;

--- a/src/main/java/ua_parser/CurrentParser.java
+++ b/src/main/java/ua_parser/CurrentParser.java
@@ -1,0 +1,16 @@
+package ua_parser;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class CurrentParser extends Parser {
+    private static final String REGEX_YAML_PATH = "/ua_parser/current/regexes.yaml";
+
+    public CurrentParser() {
+        this(CurrentParser.class.getResourceAsStream(REGEX_YAML_PATH));
+    }
+
+    public CurrentParser(InputStream regexYaml) {
+        super(regexYaml, false);
+    }
+}

--- a/src/main/java/ua_parser/LegacyParser.java
+++ b/src/main/java/ua_parser/LegacyParser.java
@@ -1,0 +1,16 @@
+package ua_parser;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class LegacyParser extends Parser {
+    private static final String REGEX_YAML_PATH = "/ua_parser/legacy/regexes.yaml";
+
+    public LegacyParser() {
+        this(LegacyParser.class.getResourceAsStream(REGEX_YAML_PATH));
+    }
+
+    public LegacyParser(InputStream regexYaml) {
+        super(regexYaml, true);
+    }
+}

--- a/src/main/java/ua_parser/Parser.java
+++ b/src/main/java/ua_parser/Parser.java
@@ -29,19 +29,14 @@ import org.yaml.snakeyaml.constructor.SafeConstructor;
  *
  * @author Steve Jiang (@sjiang) &lt;gh at iamsteve com&gt;
  */
-public class Parser {
+abstract public class Parser {
 
-  private static final String REGEX_YAML_PATH = "/ua_parser/legacy/regexes.yaml";
   private UserAgentParser uaParser;
   private OSParser osParser;
   private DeviceParser deviceParser;
 
-  public Parser() throws IOException {
-    this(Parser.class.getResourceAsStream(REGEX_YAML_PATH));
-  }
-
-  public Parser(InputStream regexYaml) {
-    initialize(regexYaml);
+  public Parser(InputStream regexYaml, boolean legacy) {
+    initialize(regexYaml, legacy);
   }
 
   public Client parse(String agentString) {
@@ -63,7 +58,7 @@ public class Parser {
     return osParser.parse(agentString);
   }
 
-  private void initialize(InputStream regexYaml) {
+  private void initialize(InputStream regexYaml, boolean legacy) {
     Yaml yaml = new Yaml(new SafeConstructor());
     @SuppressWarnings("unchecked")
     Map<String,List<Map<String,String>>> regexConfig = (Map<String,List<Map<String,String>>>) yaml.load(regexYaml);
@@ -72,7 +67,7 @@ public class Parser {
     if (uaParserConfigs == null) {
       throw new IllegalArgumentException("user_agent_parsers is missing from yaml");
     }
-    uaParser = UserAgentParser.fromList(uaParserConfigs);
+    uaParser = UserAgentParser.fromList(uaParserConfigs, legacy);
 
     List<Map<String,String>> osParserConfigs = regexConfig.get("os_parsers");
     if (osParserConfigs == null) {

--- a/src/main/java/ua_parser/Parser.java
+++ b/src/main/java/ua_parser/Parser.java
@@ -31,7 +31,7 @@ import org.yaml.snakeyaml.constructor.SafeConstructor;
  */
 public class Parser {
 
-  private static final String REGEX_YAML_PATH = "/ua_parser/regexes.yaml";
+  private static final String REGEX_YAML_PATH = "/ua_parser/legacy/regexes.yaml";
   private UserAgentParser uaParser;
   private OSParser osParser;
   private DeviceParser deviceParser;

--- a/src/main/java/ua_parser/UserAgentParser.java
+++ b/src/main/java/ua_parser/UserAgentParser.java
@@ -103,18 +103,31 @@ public class UserAgentParser {
       if (v1Replacement != null) {
         v1 = v1Replacement;
       } else if (groupCount >= 2) {
-        v1 = matcher.group(2);
+        String group2 = matcher.group(2);
+        if (!isBlank(group2)) {
+          v1 = group2;
+        }
       }
 
       if (v2Replacement != null) {
         v2 = v2Replacement;
       } else if (groupCount >= 3) {
-        v2 = matcher.group(3);
+        String group3 = matcher.group(3);
+        if (!isBlank(group3)) {
+          v2 = group3;
+        }
         if (groupCount >= 4) {
-          v3 = matcher.group(4);
+          String group4 = matcher.group(4);
+          if (!isBlank(group4)) {
+            v3 = group4;
+          }
         }
       }
       return family == null ? null : new UserAgent(family, v1, v2, v3);
+    }
+    
+    private boolean isBlank(String value) {
+      return value == null || value.isEmpty();
     }
   }
 }

--- a/src/test/java/ua_parser/CachingParserTest.java
+++ b/src/test/java/ua_parser/CachingParserTest.java
@@ -14,12 +14,7 @@ import org.junit.Test;
  * @author niels
  *
  */
-public class CachingParserTest extends ParserTest {
-
-  @Before
-  public void initParser() throws Exception {
-    parser = new CachingParser();
-  }
+public class CachingParserTest extends CurrentParserTest {
 
   @Override
   Parser parserFromStringConfig(String configYamlAsString) throws Exception {

--- a/src/test/java/ua_parser/CurrentParserTest.java
+++ b/src/test/java/ua_parser/CurrentParserTest.java
@@ -1,0 +1,44 @@
+package ua_parser;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class CurrentParserTest extends ParserTestBase {
+
+    @Before
+    public void initParser() {
+        this.parser = new CurrentParser();
+    }
+
+    @Test
+    public void testParseAll() {
+        String agentString1 = "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.4; fr; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5,gzip(gfe),gzip(gfe)";
+        String agentString2 = "Mozilla/5.0 (iPhone; CPU iPhone OS 5_1_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9B206 Safari/7534.48.3";
+
+        Client expected1 = new Client(new UserAgent("Firefox", "3", "5", "5"),
+                                      new OS("Mac OS X", "10", "4", null, null),
+                                      new Device("Mac", "Apple", "Mac"));
+        Client expected2 = new Client(new UserAgent("Mobile Safari", "5", "1", null),
+                                      new OS("iOS", "5", "1", "1", null),
+                                      new Device("iPhone", "Apple", "iPhone"));
+
+        assertThat(parser.parse(agentString1), is(expected1));
+        assertThat(parser.parse(agentString2), is(expected2));
+    }
+
+    @Override
+    String getResourcePath() {
+        return "/ua_parser/current/";
+    }
+
+    Parser parserFromStringConfig(String configYamlAsString) throws Exception {
+        InputStream yamlInput = new ByteArrayInputStream(configYamlAsString.getBytes("UTF8"));
+        return new CurrentParser(yamlInput);
+    }
+}

--- a/src/test/java/ua_parser/LegacyParserTest.java
+++ b/src/test/java/ua_parser/LegacyParserTest.java
@@ -1,0 +1,44 @@
+package ua_parser;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class LegacyParserTest extends ParserTestBase {
+
+    @Before
+    public void initParser() {
+        this.parser = new LegacyParser();
+    }
+
+    @Test
+    public void testParseAll() {
+        String agentString1 = "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.4; fr; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5,gzip(gfe),gzip(gfe)";
+        String agentString2 = "Mozilla/5.0 (iPhone; CPU iPhone OS 5_1_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9B206 Safari/7534.48.3";
+
+        Client expected1 = new Client(new UserAgent("Firefox", "3", "5", "5"),
+                                      new OS("Mac OS X", "10", "4", null, null),
+                                      new Device("Other", null, null));
+        Client expected2 = new Client(new UserAgent("Mobile Safari", "5", "1", null),
+                                      new OS("iOS", "5", "1", "1", null),
+                                      new Device("iPhone", "Apple", "iPhone"));
+
+        assertThat(parser.parse(agentString1), is(expected1));
+        assertThat(parser.parse(agentString2), is(expected2));
+    }
+
+    @Override
+    String getResourcePath() {
+        return "/ua_parser/legacy/";
+    }
+
+    Parser parserFromStringConfig(String configYamlAsString) throws Exception {
+        InputStream yamlInput = new ByteArrayInputStream(configYamlAsString.getBytes("UTF8"));
+        return new LegacyParser(yamlInput);
+    }
+}

--- a/src/test/java/ua_parser/ParserTest.java
+++ b/src/test/java/ua_parser/ParserTest.java
@@ -34,7 +34,7 @@ import org.yaml.snakeyaml.Yaml;
  * @author Steve Jiang (@sjiang) <gh at iamsteve com>
  */
 public class ParserTest {
-  final String TEST_RESOURCE_PATH = "/ua_parser/";
+  final String TEST_RESOURCE_PATH = "/ua_parser/legacy/";
   Yaml yaml = new Yaml();
   Parser parser;
 
@@ -126,7 +126,9 @@ public class ParserTest {
       if (testCase.containsKey("js_ua")) continue;
 
       String uaString = testCase.get("user_agent_string");
-      assertThat(uaString, parser.parseUserAgent(uaString), is(UserAgent.fromMap(testCase)));
+      UserAgent os = parser.parseUserAgent(uaString);
+      UserAgent fromMap = UserAgent.fromMap(testCase);
+      assertThat(uaString, os, is(fromMap));
     }
   }
 

--- a/src/test/java/ua_parser/ParserTestBase.java
+++ b/src/test/java/ua_parser/ParserTestBase.java
@@ -33,15 +33,11 @@ import org.yaml.snakeyaml.Yaml;
  *
  * @author Steve Jiang (@sjiang) <gh at iamsteve com>
  */
-public class ParserTest {
-  final String TEST_RESOURCE_PATH = "/ua_parser/legacy/";
+abstract public class ParserTestBase {
   Yaml yaml = new Yaml();
   Parser parser;
 
-  @Before
-  public void initParser() throws Exception {
-    parser = new Parser();
-  }
+  abstract String getResourcePath();
 
   @Test
   public void testParseUserAgent() {
@@ -75,22 +71,6 @@ public class ParserTest {
   }
 
   @Test
-  public void testParseAll() {
-    String agentString1 = "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.4; fr; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5,gzip(gfe),gzip(gfe)";
-    String agentString2 = "Mozilla/5.0 (iPhone; CPU iPhone OS 5_1_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9B206 Safari/7534.48.3";
-
-    Client expected1 = new Client(new UserAgent("Firefox", "3", "5", "5"),
-                                  new OS("Mac OS X", "10", "4", null, null),
-                                  new Device("Other", null, null));
-    Client expected2 = new Client(new UserAgent("Mobile Safari", "5", "1", null),
-                                  new OS("iOS", "5", "1", "1", null),
-                                  new Device("iPhone", "Apple", "iPhone"));
-
-    assertThat(parser.parse(agentString1), is(expected1));
-    assertThat(parser.parse(agentString2), is(expected2));
-  }
-
-  @Test
   public void testReplacementQuoting() throws Exception {
     String testConfig = "user_agent_parsers:\n"
                       + "  - regex: 'ABC([\\\\0-9]+)'\n"
@@ -115,7 +95,7 @@ public class ParserTest {
   }
 
   void testUserAgentFromYaml(String filename) {
-    InputStream yamlStream = this.getClass().getResourceAsStream(TEST_RESOURCE_PATH + filename);
+    InputStream yamlStream = this.getClass().getResourceAsStream(getResourcePath() + filename);
 
     @SuppressWarnings("unchecked")
     Map<String, List<Map<String,String>>> entries = (Map<String, List<Map<String,String>>>)yaml.load(yamlStream);
@@ -133,7 +113,7 @@ public class ParserTest {
   }
 
   void testOSFromYaml(String filename) {
-    InputStream yamlStream = this.getClass().getResourceAsStream(TEST_RESOURCE_PATH + filename);
+    InputStream yamlStream = this.getClass().getResourceAsStream(getResourcePath() + filename);
 
     @SuppressWarnings("unchecked")
     Map<String, List<Map<String,String>>> entries = (Map<String, List<Map<String,String>>>)yaml.load(yamlStream);
@@ -149,7 +129,7 @@ public class ParserTest {
   }
 
   void testDeviceFromYaml(String filename) {
-    InputStream yamlStream = this.getClass().getResourceAsStream(TEST_RESOURCE_PATH + filename);
+    InputStream yamlStream = this.getClass().getResourceAsStream(getResourcePath() + filename);
 
     @SuppressWarnings("unchecked")
     Map<String, List<Map<String,String>>> entries = (Map<String, List<Map<String,String>>>)yaml.load(yamlStream);
@@ -162,8 +142,5 @@ public class ParserTest {
     }
   }
 
-  Parser parserFromStringConfig(String configYamlAsString) throws Exception {
-    InputStream yamlInput = new ByteArrayInputStream(configYamlAsString.getBytes("UTF8"));
-    return new Parser(yamlInput);
-  }
+  abstract Parser parserFromStringConfig(String configYamlAsString) throws Exception;
 }


### PR DESCRIPTION
This exposes two different versions of `uap-core` through `uap-java`. Some notes about the changes:
- CurrentParser and LegacyParser have been extracted as distinct classes because I wanted to abstract out dealing with the underlying regex file, There has also been one code change in the `equals` method of `UserAgent` in the parent repo accommodating for newer versions of the regex list - there's a switch which turns it on in `CurrentParser` to ensure maximum compatibility.
- I verified that CachingParser is not used in dmp, so I did not split it out, making only a minimal code change so that it points to the newer version.